### PR TITLE
New Github-owned domain

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@ const GIT_CONTAINER_NAME = "Git";
 const GIT_CONTAINER_COLOR = "purple";
 const GIT_CONTAINER_ICON = "briefcase";
 
-let GITHUB_DOMAINS = ["github.com", "github.io", "githubapp.com", "githubusercontent.com"];
+let GITHUB_DOMAINS = ["github.com", "github.io", "githubapp.com", "githubusercontent.com", "choosealicense.com"];
 
 let GITLAB_DOMAINS = ["gitlab.com", "gitlab-static.net"];
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Git Container",
-    "version": "1.0.2",
+    "version": "1.0.3",
 
     "description": "Git Container isolates your Git hosting service activity from the rest of your web activity in order to prevent these services from tracking you via third party cookies.",
 


### PR DESCRIPTION
Added https://choosealicense.com according to #2 .